### PR TITLE
Optimize Build Times For Driver Stations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,6 +71,6 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
   "terminal.integrated.defaultProfile.windows": "Git Bash",
-  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx16G -Xms100m -Xlog:disable",
+  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx32G -Xms100m -Xlog:disable",
   "java.compile.nullAnalysis.mode": "disabled"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -66,11 +66,6 @@ task(replayWatch, type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
 }
 dependencies {
-    compileOnly("org.projectlombok:lombok:1.18.42")
-	annotationProcessor("org.projectlombok:lombok:1.18.42")
-
-	testCompileOnly("org.projectlombok:lombok:1.18.42")
-	testAnnotationProcessor("org.projectlombok:lombok:1.18.42")
 
     annotationProcessor wpi.java.deps.wpilibAnnotations()
     implementation wpi.java.deps.wpilib()

--- a/src/main/java/frc/robot/FieldConstants.java
+++ b/src/main/java/frc/robot/FieldConstants.java
@@ -11,8 +11,6 @@ import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.Filesystem;
 import frc.robot.math.geometry.Rectangle;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * Field geometry and reference points for path planning, vision, and alignment.
@@ -782,7 +780,6 @@ public class FieldConstants {
      * <p>
      * The {@link #jsonFolder} maps to a subdirectory under deploy/apriltags/.
      */
-    @RequiredArgsConstructor
     public enum FieldType {
         /** Field built from AndyMark elements. */
         ANDYMARK("andymark"),
@@ -792,8 +789,25 @@ public class FieldConstants {
         ROSBOT("rosbot");
 
         /** Deploy folder name containing JSON layouts for this field type. */
-        @Getter
         private final String jsonFolder;
+
+        /**
+         * Creates a new FieldType with the specified JSON folder name.
+         *
+         * @param jsonFolder the deploy folder name
+         */
+        FieldType(String jsonFolder) {
+            this.jsonFolder = jsonFolder;
+        }
+
+        /**
+         * Gets the deploy folder name for this field type.
+         *
+         * @return the JSON folder name
+         */
+        public String getJsonFolder() {
+            return jsonFolder;
+        }
     }
 
     /**
@@ -812,6 +826,11 @@ public class FieldConstants {
         private volatile AprilTagFieldLayout layout;
         private volatile String layoutString;
 
+        /**
+         * Creates a new AprilTagLayoutType with the specified name.
+         *
+         * @param name the name of the layout
+         */
         AprilTagLayoutType(String name) {
             this.name = name;
         }


### PR DESCRIPTION
I was able to get compile times down to 14 seconds just by removing lombok. I'm using a i5 4 core form 2015 for testing which I believe is on par with our driver stations in shop.
<img width="1787" height="355" alt="image" src="https://github.com/user-attachments/assets/17bb382f-78b1-468c-81a5-06b41003c68c" />
